### PR TITLE
Fix Invalid Integer error messages when passing unit tests

### DIFF
--- a/test.ini
+++ b/test.ini
@@ -8,6 +8,9 @@ use = config:./ckan/test-core.ini
 
 ckan.site_url = http://127.0.0.1:5000/
 
+# Disable test css as we aren't using it and creates requests to URLs
+# raising ValidationErrors. See #46
+ckan.template_head_end = <-- template_head_end -->
 ckan.legacy_templates = no
 ckan.plugins = privatedatasets
 


### PR DESCRIPTION
This PR fixes all those `ValidationError: {'offset': [u'Invalid integer']}` errors reported when executing the tests.